### PR TITLE
Cross platform compatibility + other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ I've only tested this on MacOS.
    - example: `"supercollider.sclang.cmd": "/Applications/SuperCollider.app/Contents/MacOS/sclang",`
 4. the `scvsc` commands will be available in your vscode command palette, and you can map them to whatever keyboard shortcuts you like.
 
+### Installing for development
+
+1. Clone repository
+2. Run `npm install` in repo root at the command line.
+3. Open `extension.js` in VSCode and press `F5`. Select the option to run the "Extension Development Host."
+4. Open a `.scd` file. You may be prompted to install the HyperScope vscode extension, allow it. You will see an "sclang" indicator in the lower left.
+5. Press `Ctrl+Shift+P` to open the command palette. Search for "SuperCollider" to find options such as "start sclang."
+
 ## Reasonable Future Improvements
 
 - open up docs in browser

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ I've only tested this on MacOS.
 2. Install [SuperCollider](https://supercollider.github.io/).
 3. (optional) configure the location of your `sclang` instance in your vscode `settings.json`:
    - example: `"supercollider.sclang.cmd": "/Applications/SuperCollider.app/Contents/MacOS/sclang",`
-4. the `scvsc` commands will be available in your vscode command palette, and you can map them to whatever keyboard shortcuts you like.
+4. The `scvsc` commands will be available in your vscode command palette, and you can map them to whatever keyboard shortcuts you like.
+5. Alternatively, if you want to emulate the SCIDE keybindings, go to File -> Preferences -> Settings -> Extensions -> scvsc and set "Use Scide Keybindings" to `true`.
+
 
 ### Installing for development
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ I've only tested this on MacOS.
 2. Run `npm install` in repo root at the command line.
 3. Open `extension.js` in VSCode and press `F5`. Select the option to run the "Extension Development Host."
 4. Open a `.scd` file. You may be prompted to install the HyperScope vscode extension, allow it. You will see an "sclang" indicator in the lower left.
-5. Press `Ctrl+Shift+P` to open the command palette. Search for "SuperCollider" to find options such as "start sclang."
 
 ## Reasonable Future Improvements
 

--- a/extension.js
+++ b/extension.js
@@ -37,6 +37,8 @@ async function activate(context) {
   const statusBar = vscode.window.createStatusBarItem('scstatus', 2);
 
   statusBar.text = SCLANG_STATUS_BAR_OFF;
+  statusBar.command = "supercollider.toggleSCLang";
+  statusBar.tooltip = "Click to boot or quit the SuperCollider interpreter.";
   statusBar.show();
 
   // This refreshes the token scope, but I don't think this is optimized.. but I haven't run into issues yet.
@@ -52,66 +54,81 @@ async function activate(context) {
     context.subscriptions
   );
 
-  const startSCLang = vscode.commands.registerCommand(
+  async function startSclang() {
+    if (lang) {
+      postWindow.appendLine(
+        'there is already an insteand of sclang running.'
+      );
+      return;
+    }
+    try {
+      lang = new Lang({
+        sclang: scLangPath || getDefaultSclangExecutable(),
+      });
+
+      lang.on('stdout', (message) => {
+        if (message == '\n') return;
+        postWindow.append(message);
+      });
+
+      lang.on('stderr', (message) => postWindow.append(message.trim()));
+
+      // Could probably conditional this based on a user config
+      postWindow.show();
+
+      await lang.boot();
+
+      postWindow.appendLine('SCVSC: sclang is ready');
+      statusBar.text = SCLANG_STATUS_BAR_ON;
+      statusBar.show();
+    } catch (err) {
+      postWindow.appendLine(err);
+      console.log(err);
+    }
+  }
+
+  async function stopSclang() {
+    if (!lang) {
+      postWindow.appendLine('sclang is not currently running.');
+      return;
+    }
+
+    try {
+      await lang.quit();
+      lang = null;
+      statusBar.text = SCLANG_STATUS_BAR_OFF;
+      statusBar.show();
+    } catch (err) {
+      postWindow.appendLine(err);
+      console.log(err);
+    }
+  }
+
+  async function toggleSclang() {
+    if (lang === null) {
+      startSclang();
+    } else {
+      stopSclang();
+    }
+  }
+
+  const startSCLangCommand = vscode.commands.registerCommand(
     'supercollider.startSCLang',
-    async () => {
-      if (lang) {
-        postWindow.appendLine(
-          'there is already an insteand of sclang running.'
-        );
-        return;
-      }
-
-      try {
-        lang = new Lang({
-          sclang: scLangPath || getDefaultSclangExecutable(),
-        });
-
-        lang.on('stdout', (message) => {
-          if (message == '\n') return;
-          postWindow.append(message);
-        });
-
-        lang.on('stderr', (message) => postWindow.append(message.trim()));
-
-        // Could probably conditional this based on a user config
-        postWindow.show();
-
-        await lang.boot();
-
-        postWindow.appendLine('SCVSC: sclang is ready');
-        statusBar.text = SCLANG_STATUS_BAR_ON;
-        statusBar.show();
-      } catch (err) {
-        postWindow.appendLine(err);
-        console.log(err);
-      }
-    }
+    startSclang
   );
+  context.subscriptions.push(startSCLangCommand);
 
-  context.subscriptions.push(startSCLang);
-
-  const stopSCLang = vscode.commands.registerCommand(
+  const stopSCLangCommand = vscode.commands.registerCommand(
     'supercollider.stopSCLang',
-    async () => {
-      if (!lang) {
-        postWindow.appendLine('sclang is not currently running.');
-        return;
-      }
-
-      try {
-        await lang.quit();
-        lang = null;
-        statusBar.text = SCLANG_STATUS_BAR_OFF;
-        statusBar.show();
-      } catch (err) {
-        postWindow.appendLine(err);
-        console.log(err);
-      }
-    }
+    stopSclang
   );
+  context.subscriptions.push(stopSCLangCommand);
 
-  context.subscriptions.push(stopSCLang);
+  const toggleSCLangCommand = vscode.commands.registerCommand(
+    'supercollider.toggleSCLang',
+    toggleSclang
+  );
+  context.subscriptions.push(toggleSCLangCommand);
 
   const bootSCServer = vscode.commands.registerCommand(
     'supercollider.bootServer',

--- a/extension.js
+++ b/extension.js
@@ -5,6 +5,10 @@ const { stringifyError } = require('./util');
 const Lang = require('supercolliderjs').lang.default;
 const { flashHighlight } = require('./util');
 
+const SCLANG_STATUS_BAR = 'sclang';
+const SCLANG_STATUS_BAR_OFF = `${SCLANG_STATUS_BAR} ⭕`;
+const SCLANG_STATUS_BAR_ON = `${SCLANG_STATUS_BAR} 🟢`;
+
 let lang = null;
 
 function getDefaultSclangExecutable() {
@@ -32,7 +36,7 @@ async function activate(context) {
   const postWindow = vscode.window.createOutputChannel('vscsc postWindow');
   const statusBar = vscode.window.createStatusBarItem('scstatus', 2);
 
-  statusBar.text = 'sclang 🔴';
+  statusBar.text = SCLANG_STATUS_BAR_OFF;
   statusBar.show();
 
   // This refreshes the token scope, but I don't think this is optimized.. but I haven't run into issues yet.
@@ -76,7 +80,7 @@ async function activate(context) {
         await lang.boot();
 
         postWindow.appendLine('SCVSC: sclang is ready');
-        statusBar.text = 'sclang 🟢';
+        statusBar.text = SCLANG_STATUS_BAR_ON;
         statusBar.show();
       } catch (err) {
         postWindow.appendLine(err);
@@ -98,7 +102,7 @@ async function activate(context) {
       try {
         await lang.quit();
         lang = null;
-        statusBar.text = 'sclang 🔴';
+        statusBar.text = SCLANG_STATUS_BAR_OFF;
         statusBar.show();
       } catch (err) {
         postWindow.appendLine(err);

--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,28 @@
 const vscode = require('vscode');
+const fs = require('fs');
+const path = require('path');
 const { stringifyError } = require('./util');
 const Lang = require('supercolliderjs').lang.default;
 const { flashHighlight } = require('./util');
 
 let lang = null;
+
+function getDefaultSclangExecutable() {
+  switch (process.platform) {
+    case 'darwin':
+      return '/Applications/SuperCollider.app/Contents/MacOS/sclang';
+    case 'win32':
+      const root = 'C:\\Program Files';
+      const directories = fs.readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && entry.name.startsWith("SuperCollider-"));
+      if (directories.length > 0) {
+        return path.join(root, directories[0].name, 'sclang.exe');
+      }
+      return 'sclang';
+    default:
+      return 'sclang';
+  }
+}
 
 async function activate(context) {
   const configuration = vscode.workspace.getConfiguration();
@@ -41,9 +60,7 @@ async function activate(context) {
 
       try {
         lang = new Lang({
-          sclang:
-            scLangPath ||
-            '/Applications/SuperCollider.app/Contents/MacOS/sclang',
+          sclang: scLangPath || getDefaultSclangExecutable(),
         });
 
         lang.on('stdout', (message) => {

--- a/extension.js
+++ b/extension.js
@@ -1,32 +1,14 @@
 const vscode = require('vscode');
-const fs = require('fs');
-const path = require('path');
 const { stringifyError } = require('./util');
 const Lang = require('supercolliderjs').lang.default;
 const { flashHighlight } = require('./util');
+const { getDefaultSclangExecutable } = require('./util');
 
 const SCLANG_STATUS_BAR = 'sclang';
 const SCLANG_STATUS_BAR_OFF = `${SCLANG_STATUS_BAR} ⭕`;
 const SCLANG_STATUS_BAR_ON = `${SCLANG_STATUS_BAR} 🟢`;
 
 let lang = null;
-
-function getDefaultSclangExecutable() {
-  switch (process.platform) {
-    case 'darwin':
-      return '/Applications/SuperCollider.app/Contents/MacOS/sclang';
-    case 'win32':
-      const root = 'C:\\Program Files';
-      const directories = fs.readdirSync(root, { withFileTypes: true })
-        .filter((entry) => entry.isDirectory() && entry.name.startsWith("SuperCollider-"));
-      if (directories.length > 0) {
-        return path.join(root, directories[0].name, 'sclang.exe');
-      }
-      return 'sclang';
-    default:
-      return 'sclang';
-  }
-}
 
 async function activate(context) {
   const configuration = vscode.workspace.getConfiguration();

--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
         "category": "SuperCollider"
       },
       {
+        "command": "supercollider.toggleSCLang",
+        "title": "Start/stop sclang",
+        "category": "SuperCollider"
+      },
+      {
         "command": "supercollider.bootServer",
         "title": "Boot a SuperCollider Server (scsynth)",
         "category": "SuperCollider"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "configuration": [
       {
         "type": "object",
-        "title": "SuperCollider Configuration",
+        "title": "SuperCollider",
         "properties": {
           "supercollider.sclang.cmd": {
             "type": [
@@ -33,9 +33,42 @@
             "description": "Specifies the correct sclang command for your SuperCollider installation."
           }
         }
+      },
+      {
+        "type": "object",
+        "title": "SCVSC Editor",
+        "properties": {
+          "scvsc.useScideKeybindings": {
+            "type": [
+              "boolean"
+            ],
+            "default": false,
+            "description": "If enabled, emulate keybindings from SCIDE."
+          }
+        }
       }
     ],
-    "keybindings": [],
+    "keybindings": [
+      {
+        "command": "supercollider.hush",
+        "key": "ctrl+.",
+        "mac": "cmd+.",
+        "when": "editorLangId == supercollider && config.scvsc.useScideKeybindings",
+        "comment": "Safety-critical command to override extremely loud sounds, so the context is more generic than other commands."
+      },
+      {
+        "command": "supercollider.bootServer",
+        "key": "ctrl+b",
+        "mac": "cmd+b",
+        "when": "editorTextFocus && config.scvsc.useScideKeybindings"
+      },
+      {
+        "command": "supercollider.evalRegion",
+        "key": "ctrl+enter",
+        "mac": "cmd+enter",
+        "when": "editorTextFocus && config.scvsc.useScideKeybindings"
+      }
+    ],
     "commands": [
       {
         "command": "supercollider.startSCLang",

--- a/util.js
+++ b/util.js
@@ -1,4 +1,23 @@
+const fs = require('fs');
+const path = require('path');
 const vscode = require('vscode');
+
+function getDefaultSclangExecutable() {
+  switch (process.platform) {
+    case 'darwin':
+      return '/Applications/SuperCollider.app/Contents/MacOS/sclang';
+    case 'win32':
+      const root = 'C:\\Program Files';
+      const directories = fs.readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && entry.name.startsWith("SuperCollider-"));
+      if (directories.length > 0) {
+        return path.join(root, directories[0].name, 'sclang.exe');
+      }
+      return 'sclang';
+    default:
+      return 'sclang';
+  }
+}
 
 function stringifyError(value) {
   const { type, error } = value;
@@ -35,4 +54,5 @@ function flashHighlight(editor, range, duration = 250) {
 module.exports = {
   flashHighlight,
   stringifyError,
+  getDefaultSclangExecutable,
 };


### PR DESCRIPTION
Thanks for this project, I'm looking forward to using this in my workflow. Some fixes:

- Add instructions for development setup
- Detect sclang correctly on Linux and Windows
- Change "off" emoji to ⭕ for colorblind-friendliness
- Add scvsc.useScideKeybindings option to emulate some SCIDE shortcuts
- Clicking status bar icon boots or quits sclang